### PR TITLE
Add `@latest` to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Regardless of the LSP-compatible editor you use, you'll need to install
 `bufls` so that it's available on your `$PATH`.
 
 ```bash
-go install github.com/bufbuild/buf-language-server/cmd/bufls
+go install github.com/bufbuild/buf-language-server/cmd/bufls@latest
 ```
 
 ### Vim


### PR DESCRIPTION
Just a minor tweak to avoid

```terminal
$ go install github.com/bufbuild/buf-language-server/cmd/bufls
go: 'go install' requires a version when current directory is not in a module
        Try 'go install github.com/bufbuild/buf-language-server/cmd/bufls@latest' to install the latest version
```